### PR TITLE
Fix a C++ compliance bug.

### DIFF
--- a/internal/src/google/protobuf/map.h
+++ b/internal/src/google/protobuf/map.h
@@ -171,7 +171,7 @@ class Map {
 #if __cplusplus >= 201103L && !defined(GOOGLE_PROTOBUF_OS_APPLE)
     template<class NodeType, class... Args>
     void construct(NodeType* p, Args&&... args) {
-      new (p) NodeType(std::forward<Args>(args)...);
+      new ((pointer)p) NodeType(std::forward<Args>(args)...);
     }
 
     template<class NodeType>


### PR DESCRIPTION
A sufficiently modern C++ compiler will complain when in-place new()
is not used with the right pointer type. This patch ensures
that the proper type is specified in Map::consruct().
