### PR TITLE
Avoid `string_as_array`

### DIFF
--- a/cgo_flags.go
+++ b/cgo_flags.go
@@ -4,5 +4,5 @@
 package protobuf
 
 // #cgo CXXFLAGS: -std=c++11
-// #cgo CPPFLAGS: -DHAVE_CONFIG_H -DHAVE_PTHREAD -Iinternal/src
+// #cgo CPPFLAGS: -DLANG_CXX11 -DHAVE_CONFIG_H -DHAVE_PTHREAD -Iinternal/src
 import "C"


### PR DESCRIPTION
This function is part of the msan-unclean chain described in
https://github.com/google/protobuf/issues/1099.

We see this on the go1.6 branch in the main repo:

```
==1953==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x1a8be89 in std::string::size() const /usr/lib/gcc/x86_64-linux-gnu/4.9/../../../../include/c++/4.9/bits/basic_string.h:725:26
    #1 0x1a8be89 in std::string::empty() const /usr/lib/gcc/x86_64-linux-gnu/4.9/../../../../include/c++/4.9/bits/basic_string.h:822
    #2 0x1a8be89 in google::protobuf::string_as_array(std::string*) /go/src/github.com/cockroachdb/c-protobuf/internal/src/google/protobuf/stubs/stl_util.h:85
    #3 0x1a8be89 in google::protobuf::io::mutable_string_data(std::string*) /go/src/github.com/cockroachdb/c-protobuf/internal/src/google/protobuf/io/zero_copy_stream_impl_lite.h:361
```

Defining LANG_CXX11 morphs this into:

```
==12370==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x1533d61 in std::string::_Rep::_M_is_leaked() const /usr/lib/gcc/x86_64-linux-gnu/4.9/../../../../include/c++/4.9/bits/basic_string.h:192:24
    #1 0x1533d61 in std::string::_M_leak() /usr/lib/gcc/x86_64-linux-gnu/4.9/../../../../include/c++/4.9/bits/basic_string.h:316
    #2 0x1533d61 in std::string::operator[](unsigned long) /usr/lib/gcc/x86_64-linux-gnu/4.9/../../../../include/c++/4.9/bits/basic_string.h:860
    #3 0x1533d61 in google::protobuf::io::mutable_string_data(std::string*) /go/src/github.com/cockroachdb/c-protobuf/internal/src/google/protobuf/io/zero_copy_stream_impl_lite.h:363
```

But this code path is also hit by other msan-unclean chains, so we
end up with fewer blacklisted functions overall.

The `string_as_array` callsite affected by this:
https://github.com/google/protobuf/blob/v3.0.0-beta-2/src/google/protobuf/io/zero_copy_stream_impl_lite.h#L359:L367
