### PR TITLE
circle: remove example Go code before running tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,7 @@ dependencies:
   pre:
     - git clone --depth 1 https://chromium.googlesource.com/chromium/src/tools/clang
     - clang/scripts/update.py
+    - rm ./internal/examples/*.go
 
 machine:
   environment:

--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,8 @@
 dependencies:
   pre:
+    - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+    - sudo apt-get update
+    - sudo apt-get install gcc-6 g++-6
     - git clone --depth 1 https://chromium.googlesource.com/chromium/src/tools/clang
     - clang/scripts/update.py
     - rm ./internal/examples/*.go


### PR DESCRIPTION
This code trips up Circle's inferred `go get -t -d -v ./...`.
